### PR TITLE
Implement long related opcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC ?= gcc
 CFLAGS = -std=c99 -Os -Wall -Wextra
 
 BIN = jvm
-OBJS = jvm.o stack.o
+OBJS = jvm.o stack.o constant-pool.o classfile.o
 
 deps := $(OBJS:%.o=.%.o.d)
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ TESTS = \
 	Jumps \
 	PalindromeProduct \
 	Primes \
-	Recursion
+	Recursion \
+	Long
 
 check: $(addprefix tests/,$(TESTS:=-result.out))
 

--- a/classfile.c
+++ b/classfile.c
@@ -1,0 +1,188 @@
+#include "classfile.h"
+
+class_header_t get_class_header(FILE *class_file)
+{
+    return (class_header_t){
+        .magic = read_u4(class_file),
+        .major_version = read_u2(class_file),
+        .minor_version = read_u2(class_file),
+    };
+}
+
+class_info_t get_class_info(FILE *class_file)
+{
+    class_info_t info = {
+        .access_flags = read_u2(class_file),
+        .this_class = read_u2(class_file),
+        .super_class = read_u2(class_file),
+    };
+    u2 interfaces_count = read_u2(class_file);
+    assert(!interfaces_count && "This VM does not support interfaces.");
+    u2 fields_count = read_u2(class_file);
+    assert(!fields_count && "This VM does not support fields.");
+    return info;
+}
+
+/**
+ * Get the number of integer parameters that a method takes.
+ * Use the descriptor string of the method to determine its signature.
+ */
+uint16_t get_number_of_parameters(method_t *method)
+{
+    /* Type descriptors have the length ( + #params + ) + return type */
+    return strlen(method->descriptor) - 3;
+}
+
+/**
+ * Find the method with the given name and signature.
+ * The descriptor is necessary because Java allows method overloading.
+ * This only needs to be called directly to invoke main();
+ * for the invokestatic instruction, use find_method_from_index().
+ *
+ * @param name the method name, e.g. "factorial"
+ * @param desc the method descriptor string, e.g. "(I)I"
+ * @param clazz the parsed class file
+ * @return the method if it was found, or NULL
+ */
+method_t *find_method(const char *name, const char *desc, class_file_t *clazz)
+{
+    for (method_t *method = clazz->methods; method->name; method++) {
+        if (!(strcmp(name, method->name) || strcmp(desc, method->descriptor)))
+            return method;
+    }
+    return NULL;
+}
+
+/**
+ * Find the method corresponding to the given constant pool index.
+ *
+ * @param index the constant pool index of the Methodref to call
+ * @param clazz the parsed class file
+ * @return the method if it was found, or NULL
+ */
+method_t *find_method_from_index(uint16_t idx, class_file_t *clazz)
+{
+    CONSTANT_NameAndType_info *name_and_type =
+        get_method_name_and_type(&clazz->constant_pool, idx);
+    const_pool_info *name =
+        get_constant(&clazz->constant_pool, name_and_type->name_index);
+    assert(name->tag == CONSTANT_Utf8 && "Expected a UTF8");
+    const_pool_info *descriptor =
+        get_constant(&clazz->constant_pool, name_and_type->descriptor_index);
+    assert(descriptor->tag == CONSTANT_Utf8 && "Expected a UTF8");
+    return find_method((char *) name->info, (char *) descriptor->info, clazz);
+}
+
+void read_method_attributes(FILE *class_file,
+                            method_info *info,
+                            code_t *code,
+                            constant_pool_t *cp)
+{
+    bool found_code = false;
+    for (u2 i = 0; i < info->attributes_count; i++) {
+        attribute_info ainfo = {
+            .attribute_name_index = read_u2(class_file),
+            .attribute_length = read_u4(class_file),
+        };
+        long attribute_end = ftell(class_file) + ainfo.attribute_length;
+        const_pool_info *type_constant =
+            get_constant(cp, ainfo.attribute_name_index);
+        assert(type_constant->tag == CONSTANT_Utf8 && "Expected a UTF8");
+        if (!strcmp((char *) type_constant->info, "Code")) {
+            assert(!found_code && "Duplicate method code");
+            found_code = true;
+
+            code->max_stack = read_u2(class_file);
+            code->max_locals = read_u2(class_file);
+            code->code_length = read_u4(class_file);
+            code->code = malloc(code->code_length);
+            assert(code->code && "Failed to allocate method code");
+            size_t bytes_read =
+                fread(code->code, 1, code->code_length, class_file);
+            assert(bytes_read == code->code_length &&
+                   "Failed to read method code");
+        }
+        /* Skip the rest of the attribute */
+        fseek(class_file, attribute_end, SEEK_SET);
+    }
+    assert(found_code && "Missing method code");
+}
+
+#define IS_STATIC 0x0008
+
+method_t *get_methods(FILE *class_file, constant_pool_t *cp)
+{
+    u2 method_count = read_u2(class_file);
+    method_t *methods = malloc(sizeof(*methods) * (method_count + 1));
+    assert(methods && "Failed to allocate methods");
+
+    method_t *method = methods;
+    for (u2 i = 0; i < method_count; i++, method++) {
+        method_info info = {
+            .access_flags = read_u2(class_file),
+            .name_index = read_u2(class_file),
+            .descriptor_index = read_u2(class_file),
+            .attributes_count = read_u2(class_file),
+        };
+
+        const_pool_info *name = get_constant(cp, info.name_index);
+        assert(name->tag == CONSTANT_Utf8 && "Expected a UTF8");
+        method->name = (char *) name->info;
+        const_pool_info *descriptor = get_constant(cp, info.descriptor_index);
+        assert(descriptor->tag == CONSTANT_Utf8 && "Expected a UTF8");
+        method->descriptor = (char *) descriptor->info;
+
+        /* FIXME: this VM can only execute static methods, while every class
+         * has a constructor method <init>
+         */
+        if (strcmp(method->name, "<init>"))
+            assert((info.access_flags & IS_STATIC) &&
+                   "Only static methods are supported by this VM.");
+
+        read_method_attributes(class_file, &info, &method->code, cp);
+    }
+
+    /* Mark end of array with NULL name */
+    method->name = NULL;
+    return methods;
+}
+
+/**
+ * Read an entire class file.
+ * The end of the parsed methods array is marked by a method with a NULL name.
+ *
+ * @param class_file the open file to read
+ * @return the parsed class file
+ */
+class_file_t get_class(FILE *class_file)
+{
+    /* Read the leading header of the class file */
+    get_class_header(class_file);
+
+    /* Read the constant pool */
+    class_file_t clazz = {.constant_pool = get_constant_pool(class_file)};
+
+    /* Read information about the class that was compiled. */
+    get_class_info(class_file);
+
+    /* Read the list of static methods */
+    clazz.methods = get_methods(class_file, &clazz.constant_pool);
+    return clazz;
+}
+
+/**
+ * Frees the memory used by a parsed class file.
+ *
+ * @param class the parsed class file
+ */
+void free_class(class_file_t *clazz)
+{
+    constant_pool_t *cp = &clazz->constant_pool;
+    for (u2 i = 0; i < cp->constant_pool_count; i++)
+        free(cp->constant_pool[i].info);
+    free(cp->constant_pool);
+
+    for (method_t *method = clazz->methods; method->name; method++)
+        free(method->code.code);
+    free(clazz->methods);
+}

--- a/classfile.h
+++ b/classfile.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "constant-pool.h"
+#include "type.h"
+
+typedef struct {
+    u4 magic;
+    u2 minor_version;
+    u2 major_version;
+} class_header_t;
+
+typedef struct {
+    u2 access_flags;
+    u2 this_class;
+    u2 super_class;
+} class_info_t;
+
+typedef struct {
+    u2 access_flags;
+    u2 name_index;
+    u2 descriptor_index;
+    u2 attributes_count;
+} method_info;
+
+typedef struct {
+    u2 attribute_name_index;
+    u4 attribute_length;
+} attribute_info;
+
+typedef struct {
+    u2 max_stack;
+    u2 max_locals;
+    u4 code_length;
+    u1 *code;
+} code_t;
+
+typedef struct {
+    char *name;
+    char *descriptor;
+    code_t code;
+} method_t;
+
+typedef struct {
+    constant_pool_t constant_pool;
+    method_t *methods;
+} class_file_t;
+
+class_header_t get_class_header(FILE *class_file);
+class_info_t get_class_info(FILE *class_file);
+method_t *get_methods(FILE *class_file, constant_pool_t *cp);
+void read_method_attributes(FILE *class_file,
+                            method_info *info,
+                            code_t *code,
+                            constant_pool_t *cp);
+uint16_t get_number_of_parameters(method_t *method);
+method_t *find_method(const char *name, const char *desc, class_file_t *clazz);
+method_t *find_method_from_index(uint16_t idx, class_file_t *clazz);
+class_file_t get_class(FILE *class_file);
+void free_class(class_file_t *clazz);

--- a/constant-pool.c
+++ b/constant-pool.c
@@ -1,0 +1,116 @@
+#include "constant-pool.h"
+
+/* Read unsigned big-endian integers */
+u1 read_u1(FILE *class_file)
+{
+    int result = fgetc(class_file);
+    assert(result != EOF && "Reached end of file prematurely");
+    return result;
+}
+
+u2 read_u2(FILE *class_file)
+{
+    return (u2) read_u1(class_file) << 8 | read_u1(class_file);
+}
+
+u4 read_u4(FILE *class_file)
+{
+    return (u4) read_u2(class_file) << 16 | read_u2(class_file);
+}
+
+/**
+ * Get the constant at the given index in a constant pool.
+ * Assert that the index is valid (i.e. between 1 and the pool size).
+ *
+ * @param constant_pool the class's constant pool
+ * @param index the 1-indexed constant pool index
+ * @return the constant at the given index
+ */
+const_pool_info *get_constant(constant_pool_t *constant_pool, u2 index)
+{
+    assert(0 < index && index <= constant_pool->constant_pool_count &&
+           "Invalid constant pool index");
+    /* Convert 1-indexed index to 0-indexed index */
+    return &constant_pool->constant_pool[index - 1];
+}
+
+CONSTANT_NameAndType_info *get_method_name_and_type(constant_pool_t *cp, u2 idx)
+{
+    const_pool_info *method = get_constant(cp, idx);
+    assert(method->tag == CONSTANT_MethodRef && "Expected a MethodRef");
+    const_pool_info *name_and_type_constant = get_constant(
+        cp,
+        ((CONSTANT_FieldOrMethodRef_info *) method->info)->name_and_type_index);
+    assert(name_and_type_constant->tag == CONSTANT_NameAndType &&
+           "Expected a NameAndType");
+    return (CONSTANT_NameAndType_info *) name_and_type_constant->info;
+}
+
+constant_pool_t get_constant_pool(FILE *class_file)
+{
+    constant_pool_t cp = {
+        /* Constant pool count includes unused constant at index 0 */
+        .constant_pool_count = read_u2(class_file) - 1,
+        .constant_pool =
+            malloc(sizeof(const_pool_info) * cp.constant_pool_count),
+    };
+    assert(cp.constant_pool && "Failed to allocate constant pool");
+
+    const_pool_info *constant = cp.constant_pool;
+    for (u2 i = 0; i < cp.constant_pool_count; i++, constant++) {
+        constant->tag = read_u1(class_file);
+        switch (constant->tag) {
+        case CONSTANT_Utf8: {
+            u2 length = read_u2(class_file);
+            char *value = malloc(length + 1);
+            assert(value && "Failed to allocate UTF8 constant");
+            size_t bytes_read = fread(value, 1, length, class_file);
+            assert(bytes_read == length && "Failed to read UTF8 constant");
+            value[length] = '\0';
+            constant->info = (u1 *) value;
+            break;
+        }
+
+        case CONSTANT_Integer: {
+            CONSTANT_Integer_info *value = malloc(sizeof(*value));
+            assert(value && "Failed to allocate integer constant");
+            value->bytes = read_u4(class_file);
+            constant->info = (u1 *) value;
+            break;
+        }
+
+        case CONSTANT_Class: {
+            CONSTANT_Class_info *value = malloc(sizeof(*value));
+            assert(value && "Failed to allocate class constant");
+            value->string_index = read_u2(class_file);
+            constant->info = (u1 *) value;
+            break;
+        }
+
+        case CONSTANT_MethodRef:
+        case CONSTANT_FieldRef: {
+            CONSTANT_FieldOrMethodRef_info *value = malloc(sizeof(*value));
+            assert(value &&
+                   "Failed to allocate FieldRef or MethodRef constant");
+            value->class_index = read_u2(class_file);
+            value->name_and_type_index = read_u2(class_file);
+            constant->info = (u1 *) value;
+            break;
+        }
+
+        case CONSTANT_NameAndType: {
+            CONSTANT_NameAndType_info *value = malloc(sizeof(*value));
+            assert(value && "Failed to allocate NameAndType constant");
+            value->name_index = read_u2(class_file);
+            value->descriptor_index = read_u2(class_file);
+            constant->info = (u1 *) value;
+            break;
+        }
+
+        default:
+            fprintf(stderr, "Unknown constant type %d\n", constant->tag);
+            exit(1);
+        }
+    }
+    return cp;
+}

--- a/constant-pool.c
+++ b/constant-pool.c
@@ -79,6 +79,18 @@ constant_pool_t get_constant_pool(FILE *class_file)
             break;
         }
 
+        case CONSTANT_Long: {
+            CONSTANT_LongOrDouble_info *value = malloc(sizeof(*value));
+            assert(value && "Failed to allocate long constant");
+            value->high_bytes = read_u4(class_file);
+            value->low_bytes = read_u4(class_file);
+            constant->info = (u1 *) value;
+            constant++;
+            constant->info = NULL;
+            i++;
+            break;
+        }
+
         case CONSTANT_Class: {
             CONSTANT_Class_info *value = malloc(sizeof(*value));
             assert(value && "Failed to allocate class constant");

--- a/constant-pool.h
+++ b/constant-pool.h
@@ -11,6 +11,7 @@
 typedef enum {
     CONSTANT_Utf8 = 1,
     CONSTANT_Integer = 3,
+    CONSTANT_Long = 5,
     CONSTANT_Class = 7,
     CONSTANT_FieldRef = 9,
     CONSTANT_MethodRef = 10,
@@ -29,6 +30,11 @@ typedef struct {
 typedef struct {
     int32_t bytes;
 } CONSTANT_Integer_info;
+
+typedef struct {
+    u4 high_bytes;
+    u4 low_bytes;
+} CONSTANT_LongOrDouble_info;
 
 typedef struct {
     u2 name_index;

--- a/constant-pool.h
+++ b/constant-pool.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "type.h"
+
+typedef enum {
+    CONSTANT_Utf8 = 1,
+    CONSTANT_Integer = 3,
+    CONSTANT_Class = 7,
+    CONSTANT_FieldRef = 9,
+    CONSTANT_MethodRef = 10,
+    CONSTANT_NameAndType = 12,
+} const_pool_tag_t;
+
+typedef struct {
+    u2 string_index;
+} CONSTANT_Class_info;
+
+typedef struct {
+    u2 class_index;
+    u2 name_and_type_index;
+} CONSTANT_FieldOrMethodRef_info;
+
+typedef struct {
+    int32_t bytes;
+} CONSTANT_Integer_info;
+
+typedef struct {
+    u2 name_index;
+    u2 descriptor_index;
+} CONSTANT_NameAndType_info;
+
+typedef struct {
+    const_pool_tag_t tag;
+    u1 *info;
+} const_pool_info;
+
+typedef struct {
+    u2 constant_pool_count;
+    const_pool_info *constant_pool;
+} constant_pool_t;
+
+u1 read_u1(FILE *class_file);
+u2 read_u2(FILE *class_file);
+u4 read_u4(FILE *class_file);
+const_pool_info *get_constant(constant_pool_t *constant_pool, u2 index);
+CONSTANT_NameAndType_info *get_method_name_and_type(constant_pool_t *cp,
+                                                    u2 idx);
+constant_pool_t get_constant_pool(FILE *class_file);

--- a/jvm.c
+++ b/jvm.c
@@ -8,85 +8,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include "classfile.h"
+#include "constant-pool.h"
 #include "stack.h"
-
-typedef struct {
-    u4 magic;
-    u2 minor_version, major_version;
-} class_header_t;
-
-typedef struct {
-    u2 access_flags;
-    u2 this_class;
-    u2 super_class;
-} class_info_t;
-
-typedef struct {
-    u2 access_flags;
-    u2 name_index;
-    u2 descriptor_index;
-    u2 attributes_count;
-} method_info;
-
-typedef struct {
-    u2 attribute_name_index;
-    u4 attribute_length;
-} attribute_info;
-
-typedef struct {
-    u2 max_stack;
-    u2 max_locals;
-    u4 code_length;
-    u1 *code;
-} code_t;
-
-typedef struct {
-    char *name;
-    char *descriptor;
-    code_t code;
-} method_t;
-
-typedef enum {
-    CONSTANT_Utf8 = 1,
-    CONSTANT_Integer = 3,
-    CONSTANT_Class = 7,
-    CONSTANT_FieldRef = 9,
-    CONSTANT_MethodRef = 10,
-    CONSTANT_NameAndType = 12,
-} const_pool_tag_t;
-
-typedef struct {
-    u2 string_index;
-} CONSTANT_Class_info;
-
-typedef struct {
-    u2 class_index;
-    u2 name_and_type_index;
-} CONSTANT_FieldOrMethodRef_info;
-
-typedef struct {
-    int32_t bytes;
-} CONSTANT_Integer_info;
-
-typedef struct {
-    u2 name_index;
-    u2 descriptor_index;
-} CONSTANT_NameAndType_info;
-
-typedef struct {
-    const_pool_tag_t tag;
-    u1 *info;
-} const_pool_info;
-
-typedef struct {
-    u2 constant_pool_count;
-    const_pool_info *constant_pool;
-} constant_pool_t;
-
-typedef struct {
-    constant_pool_t constant_pool;
-    method_t *methods;
-} class_file_t;
 
 typedef enum {
     i_iconst_m1 = 0x2,
@@ -135,309 +59,6 @@ typedef enum {
     i_invokevirtual = 0xb6,
     i_invokestatic = 0xb8,
 } jvm_opcode_t;
-
-/* Read unsigned big-endian integers */
-
-u1 read_u1(FILE *class_file)
-{
-    int result = fgetc(class_file);
-    assert(result != EOF && "Reached end of file prematurely");
-    return result;
-}
-
-u2 read_u2(FILE *class_file)
-{
-    return (u2) read_u1(class_file) << 8 | read_u1(class_file);
-}
-
-u4 read_u4(FILE *class_file)
-{
-    return (u4) read_u2(class_file) << 16 | read_u2(class_file);
-}
-
-/**
- * Get the constant at the given index in a constant pool.
- * Assert that the index is valid (i.e. between 1 and the pool size).
- *
- * @param constant_pool the class's constant pool
- * @param index the 1-indexed constant pool index
- * @return the constant at the given index
- */
-const_pool_info *get_constant(constant_pool_t *constant_pool, u2 index)
-{
-    assert(0 < index && index <= constant_pool->constant_pool_count &&
-           "Invalid constant pool index");
-    /* Convert 1-indexed index to 0-indexed index */
-    return &constant_pool->constant_pool[index - 1];
-}
-
-CONSTANT_NameAndType_info *get_method_name_and_type(constant_pool_t *cp, u2 idx)
-{
-    const_pool_info *method = get_constant(cp, idx);
-    assert(method->tag == CONSTANT_MethodRef && "Expected a MethodRef");
-    const_pool_info *name_and_type_constant = get_constant(
-        cp,
-        ((CONSTANT_FieldOrMethodRef_info *) method->info)->name_and_type_index);
-    assert(name_and_type_constant->tag == CONSTANT_NameAndType &&
-           "Expected a NameAndType");
-    return (CONSTANT_NameAndType_info *) name_and_type_constant->info;
-}
-
-/**
- * Get the number of integer parameters that a method takes.
- * Use the descriptor string of the method to determine its signature.
- */
-uint16_t get_number_of_parameters(method_t *method)
-{
-    /* Type descriptors have the length ( + #params + ) + return type */
-    return strlen(method->descriptor) - 3;
-}
-
-/**
- * Find the method with the given name and signature.
- * The descriptor is necessary because Java allows method overloading.
- * This only needs to be called directly to invoke main();
- * for the invokestatic instruction, use find_method_from_index().
- *
- * @param name the method name, e.g. "factorial"
- * @param desc the method descriptor string, e.g. "(I)I"
- * @param clazz the parsed class file
- * @return the method if it was found, or NULL
- */
-method_t *find_method(const char *name, const char *desc, class_file_t *clazz)
-{
-    for (method_t *method = clazz->methods; method->name; method++) {
-        if (!(strcmp(name, method->name) || strcmp(desc, method->descriptor)))
-            return method;
-    }
-    return NULL;
-}
-
-/**
- * Find the method corresponding to the given constant pool index.
- *
- * @param index the constant pool index of the Methodref to call
- * @param clazz the parsed class file
- * @return the method if it was found, or NULL
- */
-method_t *find_method_from_index(uint16_t idx, class_file_t *clazz)
-{
-    CONSTANT_NameAndType_info *name_and_type =
-        get_method_name_and_type(&clazz->constant_pool, idx);
-    const_pool_info *name =
-        get_constant(&clazz->constant_pool, name_and_type->name_index);
-    assert(name->tag == CONSTANT_Utf8 && "Expected a UTF8");
-    const_pool_info *descriptor =
-        get_constant(&clazz->constant_pool, name_and_type->descriptor_index);
-    assert(descriptor->tag == CONSTANT_Utf8 && "Expected a UTF8");
-    return find_method((char *) name->info, (char *) descriptor->info, clazz);
-}
-
-class_header_t get_class_header(FILE *class_file)
-{
-    return (class_header_t){
-        .magic = read_u4(class_file),
-        .major_version = read_u2(class_file),
-        .minor_version = read_u2(class_file),
-    };
-}
-
-constant_pool_t get_constant_pool(FILE *class_file)
-{
-    constant_pool_t cp = {
-        /* Constant pool count includes unused constant at index 0 */
-        .constant_pool_count = read_u2(class_file) - 1,
-        .constant_pool =
-            malloc(sizeof(const_pool_info) * cp.constant_pool_count),
-    };
-    assert(cp.constant_pool && "Failed to allocate constant pool");
-
-    const_pool_info *constant = cp.constant_pool;
-    for (u2 i = 0; i < cp.constant_pool_count; i++, constant++) {
-        constant->tag = read_u1(class_file);
-        switch (constant->tag) {
-        case CONSTANT_Utf8: {
-            u2 length = read_u2(class_file);
-            char *value = malloc(length + 1);
-            assert(value && "Failed to allocate UTF8 constant");
-            size_t bytes_read = fread(value, 1, length, class_file);
-            assert(bytes_read == length && "Failed to read UTF8 constant");
-            value[length] = '\0';
-            constant->info = (u1 *) value;
-            break;
-        }
-
-        case CONSTANT_Integer: {
-            CONSTANT_Integer_info *value = malloc(sizeof(*value));
-            assert(value && "Failed to allocate integer constant");
-            value->bytes = read_u4(class_file);
-            constant->info = (u1 *) value;
-            break;
-        }
-
-        case CONSTANT_Class: {
-            CONSTANT_Class_info *value = malloc(sizeof(*value));
-            assert(value && "Failed to allocate class constant");
-            value->string_index = read_u2(class_file);
-            constant->info = (u1 *) value;
-            break;
-        }
-
-        case CONSTANT_MethodRef:
-        case CONSTANT_FieldRef: {
-            CONSTANT_FieldOrMethodRef_info *value = malloc(sizeof(*value));
-            assert(value &&
-                   "Failed to allocate FieldRef or MethodRef constant");
-            value->class_index = read_u2(class_file);
-            value->name_and_type_index = read_u2(class_file);
-            constant->info = (u1 *) value;
-            break;
-        }
-
-        case CONSTANT_NameAndType: {
-            CONSTANT_NameAndType_info *value = malloc(sizeof(*value));
-            assert(value && "Failed to allocate NameAndType constant");
-            value->name_index = read_u2(class_file);
-            value->descriptor_index = read_u2(class_file);
-            constant->info = (u1 *) value;
-            break;
-        }
-
-        default:
-            fprintf(stderr, "Unknown constant type %d\n", constant->tag);
-            exit(1);
-        }
-    }
-    return cp;
-}
-
-class_info_t get_class_info(FILE *class_file)
-{
-    class_info_t info = {
-        .access_flags = read_u2(class_file),
-        .this_class = read_u2(class_file),
-        .super_class = read_u2(class_file),
-    };
-    u2 interfaces_count = read_u2(class_file);
-    assert(!interfaces_count && "This VM does not support interfaces.");
-    u2 fields_count = read_u2(class_file);
-    assert(!fields_count && "This VM does not support fields.");
-    return info;
-}
-
-void read_method_attributes(FILE *class_file,
-                            method_info *info,
-                            code_t *code,
-                            constant_pool_t *cp)
-{
-    bool found_code = false;
-    for (u2 i = 0; i < info->attributes_count; i++) {
-        attribute_info ainfo = {
-            .attribute_name_index = read_u2(class_file),
-            .attribute_length = read_u4(class_file),
-        };
-        long attribute_end = ftell(class_file) + ainfo.attribute_length;
-        const_pool_info *type_constant =
-            get_constant(cp, ainfo.attribute_name_index);
-        assert(type_constant->tag == CONSTANT_Utf8 && "Expected a UTF8");
-        if (!strcmp((char *) type_constant->info, "Code")) {
-            assert(!found_code && "Duplicate method code");
-            found_code = true;
-
-            code->max_stack = read_u2(class_file);
-            code->max_locals = read_u2(class_file);
-            code->code_length = read_u4(class_file);
-            code->code = malloc(code->code_length);
-            assert(code->code && "Failed to allocate method code");
-            size_t bytes_read =
-                fread(code->code, 1, code->code_length, class_file);
-            assert(bytes_read == code->code_length &&
-                   "Failed to read method code");
-        }
-        /* Skip the rest of the attribute */
-        fseek(class_file, attribute_end, SEEK_SET);
-    }
-    assert(found_code && "Missing method code");
-}
-
-#define IS_STATIC 0x0008
-
-method_t *get_methods(FILE *class_file, constant_pool_t *cp)
-{
-    u2 method_count = read_u2(class_file);
-    method_t *methods = malloc(sizeof(*methods) * (method_count + 1));
-    assert(methods && "Failed to allocate methods");
-
-    method_t *method = methods;
-    for (u2 i = 0; i < method_count; i++, method++) {
-        method_info info = {
-            .access_flags = read_u2(class_file),
-            .name_index = read_u2(class_file),
-            .descriptor_index = read_u2(class_file),
-            .attributes_count = read_u2(class_file),
-        };
-
-        const_pool_info *name = get_constant(cp, info.name_index);
-        assert(name->tag == CONSTANT_Utf8 && "Expected a UTF8");
-        method->name = (char *) name->info;
-        const_pool_info *descriptor = get_constant(cp, info.descriptor_index);
-        assert(descriptor->tag == CONSTANT_Utf8 && "Expected a UTF8");
-        method->descriptor = (char *) descriptor->info;
-
-        /* FIXME: this VM can only execute static methods, while every class
-         * has a constructor method <init>
-         */
-        if (strcmp(method->name, "<init>"))
-            assert((info.access_flags & IS_STATIC) &&
-                   "Only static methods are supported by this VM.");
-
-        read_method_attributes(class_file, &info, &method->code, cp);
-    }
-
-    /* Mark end of array with NULL name */
-    method->name = NULL;
-    return methods;
-}
-
-/**
- * Read an entire class file.
- * The end of the parsed methods array is marked by a method with a NULL name.
- *
- * @param class_file the open file to read
- * @return the parsed class file
- */
-class_file_t get_class(FILE *class_file)
-{
-    /* Read the leading header of the class file */
-    get_class_header(class_file);
-
-    /* Read the constant pool */
-    class_file_t clazz = {.constant_pool = get_constant_pool(class_file)};
-
-    /* Read information about the class that was compiled. */
-    get_class_info(class_file);
-
-    /* Read the list of static methods */
-    clazz.methods = get_methods(class_file, &clazz.constant_pool);
-    return clazz;
-}
-
-/**
- * Frees the memory used by a parsed class file.
- *
- * @param class the parsed class file
- */
-void free_class(class_file_t *clazz)
-{
-    constant_pool_t *cp = &clazz->constant_pool;
-    for (u2 i = 0; i < cp->constant_pool_count; i++)
-        free(cp->constant_pool[i].info);
-    free(cp->constant_pool);
-
-    for (method_t *method = clazz->methods; method->name; method++)
-        free(method->code.code);
-    free(clazz->methods);
-}
 
 static inline void bipush(stack_frame_t *op_stack,
                           uint32_t pc,
@@ -525,12 +146,13 @@ static inline void iconst(stack_frame_t *op_stack, uint8_t current)
  * @param locals the array of local variables, including the method parameters.
  *               Except for parameters, the locals are uninitialized.
  * @param clazz the class file the method belongs to
- * @return if the method returns an int, a heap-allocated pointer to it;
- *         NULL if the method returns void, NULL;
+ * @return stack_entry that contain the method return value and its type. Is a
+ *         heap-allocated pointer which should be free from the caller
+ *
  */
-int32_t *execute(method_t *method,
-                 local_variable_t *locals,
-                 class_file_t *clazz)
+stack_entry_t *execute(method_t *method,
+                       local_variable_t *locals,
+                       class_file_t *clazz)
 {
     code_t code = method->code;
     stack_frame_t *op_stack = malloc(sizeof(stack_frame_t));
@@ -551,18 +173,26 @@ int32_t *execute(method_t *method,
         switch (current) {
         /* Return int from method */
         case i_ireturn: {
-            int32_t *ret = malloc(sizeof(int32_t));
-            *ret = pop_int(op_stack);
+            stack_entry_t *ret = malloc(sizeof(stack_entry_t));
+            ret->entry.int_value = (int32_t) pop_int(op_stack);
+            ret->type = STACK_ENTRY_INT;
+
             free(op_stack->store);
             free(op_stack);
+
             return ret;
         }
 
         /* Return void from method */
-        case i_return:
+        case i_return: {
+            stack_entry_t *ret = malloc(sizeof(stack_entry_t));
+            ret->type = STACK_ENTRY_NONE;
+
             free(op_stack->store);
             free(op_stack);
-            return NULL;
+
+            return ret;
+        }
 
         /* Invoke a class (static) method */
         case i_invokestatic: {
@@ -576,9 +206,17 @@ int32_t *execute(method_t *method,
             for (int i = num_params - 1; i >= 0; i--)
                 pop_to_local(op_stack, &own_locals[i]);
 
-            int32_t *exec_res = execute(own_method, own_locals, clazz);
-            if (exec_res)
-                push_int(op_stack, *exec_res);
+            stack_entry_t *exec_res = execute(own_method, own_locals, clazz);
+            switch (exec_res->type) {
+            case STACK_ENTRY_INT:
+                push_int(op_stack, exec_res->entry.int_value);
+                break;
+            case STACK_ENTRY_NONE:
+                /* nothing */
+                break;
+            default:
+                assert(0 && "unknown return type");
+            }
 
             free(exec_res);
             pc += 3;
@@ -884,6 +522,10 @@ int32_t *execute(method_t *method,
             sipush(op_stack, pc, code_buf);
             pc += 3;
             break;
+
+        default:
+            fprintf(stderr, "Unknown instruction %x\n", current);
+            exit(1);
         }
     }
     return NULL;
@@ -912,8 +554,9 @@ int main(int argc, char *argv[])
      * we lack of the support for java.lang.Object. Leave it uninitialized.
      */
     local_variable_t locals[main_method->code.max_locals];
-    int32_t *result = execute(main_method, locals, &clazz);
-    assert(!result && "main() should return void");
+    stack_entry_t *result = execute(main_method, locals, &clazz);
+    assert(result->type == STACK_ENTRY_NONE && "main() should return void");
+    free(result);
 
     free_class(&clazz);
 

--- a/stack.c
+++ b/stack.c
@@ -31,38 +31,39 @@ void push_int(stack_frame_t *stack, int32_t value)
     stack->size++;
 }
 
-/* pop top of stack value and convert to 32 bits integer */
+void push_long(stack_frame_t *stack, int64_t value)
+{
+    stack->store[stack->size].entry.long_value = value;
+    stack->store[stack->size].type = STACK_ENTRY_LONG;
+    stack->size++;
+}
+
+/* pop top of stack value and convert to 64 bits integer */
 int64_t stack_to_int(stack_value_t *entry, size_t size)
 {
     switch (size) {
     /* int8_t */
-    case 1: {
-        int8_t value;
-        value = entry->char_value;
-        return value;
-    }
+    case 1:
+        return (int8_t) entry->long_value;
     /* int16_t */
-    case 2: {
-        int16_t value;
-        value = entry->short_value;
-        return value;
-    }
+    case 2:
+        return (int16_t) entry->long_value;
     /* int32_t */
-    case 4: {
-        int32_t value;
-        value = entry->int_value;
-        return value;
-    }
+    case 4:
+        return (int32_t) entry->long_value;
+    /* int64_t */
+    case 8:
+        return (int64_t) entry->long_value;
     default:
         assert("stack entry not an interger");
         return -1;
     }
 }
 
-int32_t pop_int(stack_frame_t *stack)
+int64_t pop_int(stack_frame_t *stack)
 {
     size_t size = get_type_size(stack->store[stack->size - 1].type);
-    int32_t value = stack_to_int(&stack->store[stack->size - 1].entry, size);
+    int64_t value = stack_to_int(&stack->store[stack->size - 1].entry, size);
     stack->size--;
     return value;
 }
@@ -71,10 +72,10 @@ void pop_to_local(stack_frame_t *stack, local_variable_t *locals)
 {
     stack_entry_type_t type = stack->store[stack->size - 1].type;
     /* convert to integer */
-    if (type >= STACK_ENTRY_BYTE && type <= STACK_ENTRY_INT) {
-        int32_t value = pop_int(stack);
-        locals->entry.int_value = value;
-        locals->type = STACK_ENTRY_INT;
+    if (type >= STACK_ENTRY_BYTE && type <= STACK_ENTRY_LONG) {
+        int64_t value = pop_int(stack);
+        locals->entry.long_value = value;
+        locals->type = STACK_ENTRY_LONG;
     }
 }
 

--- a/stack.h
+++ b/stack.h
@@ -14,8 +14,8 @@ typedef enum {
     STACK_ENTRY_BYTE,
     STACK_ENTRY_SHORT,
     STACK_ENTRY_INT,
-    STACK_ENTRY_REF,
     STACK_ENTRY_LONG,
+    STACK_ENTRY_REF,
     STACK_ENTRY_DOUBLE,
     STACK_ENTRY_FLOAT
 } stack_entry_type_t;
@@ -24,6 +24,7 @@ typedef union {
     u1 char_value;
     u2 short_value;
     u4 int_value;
+    u8 long_value;
     void *ptr_value;
 } stack_value_t;
 
@@ -44,7 +45,8 @@ void init_stack(stack_frame_t *stack, size_t entry_size);
 void push_byte(stack_frame_t *stack, int8_t value);
 void push_short(stack_frame_t *stack, int16_t value);
 void push_int(stack_frame_t *stack, int32_t value);
-int pop_int(stack_frame_t *stack);
+void push_long(stack_frame_t *stack, int64_t value);
+int64_t pop_int(stack_frame_t *stack);
 void pop_to_local(stack_frame_t *stack, local_variable_t *locals);
 size_t get_type_size(stack_entry_type_t type);
 int64_t stack_to_int(stack_value_t *entry, size_t size);

--- a/tests/Long.java
+++ b/tests/Long.java
@@ -1,0 +1,17 @@
+public class Long
+{
+    public static long reutrnLong(long x) {
+        return x;
+    }
+    public static void main(final String[] array) {
+        final long n = java.lang.Long.MAX_VALUE;
+        final long n2 = 2000L;
+        System.out.println(reutrnLong(n));
+        System.out.println(n + n2);
+        System.out.println(n - n2);
+        System.out.println(n * n2);
+        System.out.println(n / n2);
+        System.out.println(n % n2);
+        System.out.println((int)n + (long)(int)n2);
+    }
+}

--- a/type.h
+++ b/type.h
@@ -5,3 +5,4 @@
 typedef uint8_t u1;
 typedef uint16_t u2;
 typedef uint32_t u4;
+typedef uint64_t u8;


### PR DESCRIPTION
This patch have two main changes:

* move jvm related functions into `jvm_info` file
* support `long` instruction

Please notice that normal JVM uses one stack element to store 4 bytes value, but current implementation stores 8 bytes value so it only support that first parameter is type `long` in each function. 

If two or more parameter in function are `long`, then it cannot get correct index from stack.