### PR TITLE
Implement class heap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,12 @@ CC ?= gcc
 CFLAGS = -std=c99 -Os -Wall -Wextra
 
 BIN = jvm
-OBJS = jvm.o stack.o constant-pool.o classfile.o
+OBJS = \
+	jvm.o \
+	stack.o \
+	constant-pool.o \
+	classfile.o \
+	class-heap.o
 
 deps := $(OBJS:%.o=.%.o.d)
 
@@ -37,7 +42,8 @@ TESTS = \
 	PalindromeProduct \
 	Primes \
 	Recursion \
-	Long
+	Long \
+	Caller
 
 check: $(addprefix tests/,$(TESTS:=-result.out))
 

--- a/class-heap.c
+++ b/class-heap.c
@@ -1,0 +1,62 @@
+#include "class-heap.h"
+
+// FIXME: use dynamic structure to grow heap size dynamically
+#define MAX_HEAP_SIZE 100
+
+static class_heap_t class_heap;
+
+void init_class_heap()
+{
+    /* max contain 100 class file */
+    class_heap.class_info = malloc(sizeof(meta_class_t *) * MAX_HEAP_SIZE);
+    class_heap.length = 0;
+}
+
+/* the name parameter should contain ".class" suffix and be cut in this function
+ */
+void add_class(class_file_t *clazz, char *name)
+{
+    meta_class_t *meta_class = malloc(sizeof(meta_class_t));
+    meta_class->clazz = clazz;
+    /* assume class file is in the same directory */
+    /* -6 mean clip ".class" in posfix */
+    meta_class->name = malloc((strlen(name) + 1 - 6));
+    strncpy(meta_class->name, name, strlen(name) - 6);
+    meta_class->name[strlen(name) - 6] = '\0';
+    class_heap.class_info[class_heap.length++] = meta_class;
+}
+
+class_file_t *find_class_from_heap(char *value)
+{
+    for (int i = 0; i < class_heap.length; ++i) {
+        if (strcmp(class_heap.class_info[i]->name, value) == 0) {
+            return class_heap.class_info[i]->clazz;
+        }
+    }
+    return NULL;
+}
+
+void free_class_heap()
+{
+    for (int i = 0; i < class_heap.length; ++i) {
+        const_pool_info *constant =
+            class_heap.class_info[i]->clazz->constant_pool.constant_pool;
+        for (u2 j = 0;
+             j <
+             class_heap.class_info[i]->clazz->constant_pool.constant_pool_count;
+             j++, constant++) {
+            free(constant->info);
+        }
+        free(class_heap.class_info[i]->clazz->constant_pool.constant_pool);
+
+        for (method_t *method = class_heap.class_info[i]->clazz->methods;
+             method->name; method++)
+            free(method->code.code);
+        free(class_heap.class_info[i]->clazz->methods);
+
+        free(class_heap.class_info[i]->clazz);
+        free(class_heap.class_info[i]->name);
+        free(class_heap.class_info[i]);
+    }
+    free(class_heap.class_info);
+}

--- a/class-heap.h
+++ b/class-heap.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "classfile.h"
+
+typedef struct {
+    u2 length;
+    meta_class_t **class_info;
+} class_heap_t;
+
+void init_class_heap();
+void free_class_heap();
+void add_class(class_file_t *clazz, char *name);
+class_file_t *find_class_from_heap(char *value);
+char *find_method_info_from_index(uint16_t idx,
+                                  class_file_t *clazz,
+                                  char **name_info,
+                                  char **descriptor_info);

--- a/classfile.h
+++ b/classfile.h
@@ -45,6 +45,11 @@ typedef struct {
     method_t *methods;
 } class_file_t;
 
+typedef struct {
+    class_file_t *clazz;
+    char *name;
+} meta_class_t;
+
 class_header_t get_class_header(FILE *class_file);
 class_info_t get_class_info(FILE *class_file);
 method_t *get_methods(FILE *class_file, constant_pool_t *cp);
@@ -56,4 +61,3 @@ uint16_t get_number_of_parameters(method_t *method);
 method_t *find_method(const char *name, const char *desc, class_file_t *clazz);
 method_t *find_method_from_index(uint16_t idx, class_file_t *clazz);
 class_file_t get_class(FILE *class_file);
-void free_class(class_file_t *clazz);

--- a/constant-pool.c
+++ b/constant-pool.c
@@ -34,16 +34,18 @@ const_pool_info *get_constant(constant_pool_t *constant_pool, u2 index)
     return &constant_pool->constant_pool[index - 1];
 }
 
-CONSTANT_NameAndType_info *get_method_name_and_type(constant_pool_t *cp, u2 idx)
+CONSTANT_FieldOrMethodRef_info *get_methodref(constant_pool_t *cp, u2 idx)
 {
     const_pool_info *method = get_constant(cp, idx);
     assert(method->tag == CONSTANT_MethodRef && "Expected a MethodRef");
-    const_pool_info *name_and_type_constant = get_constant(
-        cp,
-        ((CONSTANT_FieldOrMethodRef_info *) method->info)->name_and_type_index);
-    assert(name_and_type_constant->tag == CONSTANT_NameAndType &&
-           "Expected a NameAndType");
-    return (CONSTANT_NameAndType_info *) name_and_type_constant->info;
+    return (CONSTANT_FieldOrMethodRef_info *) method->info;
+}
+
+CONSTANT_Class_info *get_class_name(constant_pool_t *cp, u2 idx)
+{
+    const_pool_info *class = get_constant(cp, idx);
+    assert(class->tag == CONSTANT_Class && "Expected a Class");
+    return (CONSTANT_Class_info *) class->info;
 }
 
 constant_pool_t get_constant_pool(FILE *class_file)

--- a/constant-pool.h
+++ b/constant-pool.h
@@ -55,6 +55,6 @@ u1 read_u1(FILE *class_file);
 u2 read_u2(FILE *class_file);
 u4 read_u4(FILE *class_file);
 const_pool_info *get_constant(constant_pool_t *constant_pool, u2 index);
-CONSTANT_NameAndType_info *get_method_name_and_type(constant_pool_t *cp,
-                                                    u2 idx);
 constant_pool_t get_constant_pool(FILE *class_file);
+CONSTANT_FieldOrMethodRef_info *get_methodref(constant_pool_t *cp, u2 idx);
+CONSTANT_Class_info *get_class_name(constant_pool_t *cp, u2 idx);

--- a/tests/Caller.java
+++ b/tests/Caller.java
@@ -1,0 +1,11 @@
+public class Caller {
+    public static void main(String[] args) {
+        Callee.func();
+    }
+}
+
+class Callee {
+    public static void func() {
+        System.out.println(1);
+    }
+}


### PR DESCRIPTION
This patch implement class heap and push all classes into class heap.

The difference between standard JVM and pitifulvm is that standard JVM can set classpath to find classes in specific directories, but current implementation only supports classes in the current working directory or in the directory containing the first parsed class file.

Add a new test script: `Caller.java`, which calls another class in same directory.