### PR TITLE
Add more class related opcodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ TESTS = \
 	Recursion \
 	Long \
 	Caller \
-	Constructor
+	Constructor \
+	Field
 	
 check: $(addprefix tests/,$(TESTS:=-result.out))
 

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ TESTS = \
 	Long \
 	Caller \
 	Constructor \
-	Field
+	Field \
+	Static
 	
 check: $(addprefix tests/,$(TESTS:=-result.out))
 

--- a/class-heap.c
+++ b/class-heap.c
@@ -91,6 +91,11 @@ void free_class_heap()
             free(constant->info);
         }
         free(class_heap.class_info[i]->clazz->constant_pool.constant_pool);
+
+        field_t *field = class_heap.class_info[i]->clazz->fields;
+        for (u2 j = 0; j < class_heap.class_info[i]->clazz->fields_count;
+             j++, field++)
+            free(field->static_var);
         free(class_heap.class_info[i]->clazz->fields);
 
         for (method_t *method = class_heap.class_info[i]->clazz->methods;

--- a/classfile.c
+++ b/classfile.c
@@ -32,6 +32,27 @@ uint16_t get_number_of_parameters(method_t *method)
 }
 
 /**
+ * Find the field with the given name and signature.
+ * The difference between `find_field` and `object_heap:find_field_addr`
+ * is that `find_field` is used to find class level field  (i.e. static field),
+ * and `find_field_addr` is used to find object level field.
+ *
+ * @param name the field name
+ * @param desc the field descriptor string, e.g. "(I)I"
+ * @param clazz the parsed class file
+ * @return the field if it was found, or NULL
+ */
+field_t *find_field(const char *name, const char *desc, class_file_t *clazz)
+{
+    field_t *field = clazz->fields;
+    for (u2 i = 0; i < clazz->fields_count; ++i, field++) {
+        if (!(strcmp(name, field->name) || strcmp(desc, field->descriptor)))
+            return field;
+    }
+    return NULL;
+}
+
+/**
  * Find the method with the given name and signature.
  * The descriptor is necessary because Java allows method overloading.
  * This needs to be called directly to invoke main(),
@@ -218,6 +239,7 @@ field_t *get_fields(FILE *class_file, constant_pool_t *cp, class_file_t *clazz)
         const_pool_info *descriptor = get_constant(cp, info.descriptor_index);
         assert(descriptor->tag == CONSTANT_Utf8 && "Expected a UTF8");
         field->descriptor = (char *) descriptor->info;
+        field->static_var = malloc(sizeof(variable_t));
 
         read_field_attributes(class_file, &info);
     }

--- a/classfile.h
+++ b/classfile.h
@@ -51,6 +51,7 @@ typedef struct {
     char *class_name;
     char *name;
     char *descriptor;
+    variable_t *static_var; /* store static fields in the class */
 } field_t;
 
 typedef struct {
@@ -73,6 +74,7 @@ void read_method_attributes(FILE *class_file,
                             code_t *code,
                             constant_pool_t *cp);
 uint16_t get_number_of_parameters(method_t *method);
+field_t *find_field(const char *name, const char *desc, class_file_t *clazz);
 method_t *find_method(const char *name, const char *desc, class_file_t *clazz);
 method_t *find_method_from_index(uint16_t idx, class_file_t *clazz);
 class_file_t get_class(FILE *class_file);

--- a/object-heap.c
+++ b/object-heap.c
@@ -26,6 +26,18 @@ object_t *create_object(class_file_t *clazz)
     return new_obj;
 }
 
+variable_t *find_field_addr(object_t *obj, char *name)
+{
+    field_t *field = obj->class->fields;
+    for (u2 i = 0; i < obj->class->fields_count; i++, field++) {
+        if (!strcmp(field->name, name)) {
+            return &obj->value[i];
+        }
+    }
+    assert(0 && "Can't find field in the object");
+    return NULL;
+}
+
 void free_object_heap()
 {
     for (int i = 0; i < object_heap.length; ++i) {

--- a/object-heap.h
+++ b/object-heap.h
@@ -16,3 +16,4 @@ typedef struct {
 void init_object_heap();
 void free_object_heap();
 object_t *create_object(class_file_t *clazz);
+variable_t *find_field_addr(object_t *obj, char *name);

--- a/stack.c
+++ b/stack.c
@@ -43,6 +43,11 @@ void push_ref(stack_frame_t *stack, void *addr)
     stack->size++;
 }
 
+stack_entry_t top(stack_frame_t *stack)
+{
+    return stack->store[stack->size - 1];
+}
+
 /* pop top of stack value and convert to 64 bits integer */
 int64_t stack_to_int(value_t *entry, size_t size)
 {

--- a/stack.h
+++ b/stack.h
@@ -44,3 +44,4 @@ void *pop_ref(stack_frame_t *stack);
 void pop_to_local(stack_frame_t *stack, local_variable_t *locals);
 size_t get_type_size(stack_entry_type_t type);
 int64_t stack_to_int(value_t *entry, size_t size);
+stack_entry_t top(stack_frame_t *stack);

--- a/tests/Field.java
+++ b/tests/Field.java
@@ -1,0 +1,12 @@
+class Field {
+    Field(int a, int b, int c) {
+        x = a;
+        y = b;
+        z = c;
+    }
+    public static void main(String[] args) {
+        Field f = new Field(1, 2, 3);
+        System.out.println(f.x + f.y + f.z);
+    }
+    int x, y, z;
+}

--- a/tests/Static.java
+++ b/tests/Static.java
@@ -1,0 +1,23 @@
+public class Static {
+    static int x, y, z;
+    public static void main(String[] args) {
+        x = 3;
+        y = 4;
+        z = 5;
+        StaticA.x = 1;
+        StaticB.x = Static.x + StaticA.x;
+        System.out.println(Static.x);
+        System.out.println(Static.y);
+        System.out.println(Static.z);
+        System.out.println(StaticA.x);
+        System.out.println(StaticB.x);
+    }
+}
+
+class StaticA {
+    static int x;
+}
+
+class StaticB {
+    static int x;
+} 


### PR DESCRIPTION
This patch implement four class related opcodes:
* `getstatic`
* `putstatic`
* `getfield`
* `putfield`

Please notice that static initialization and fields from objects' parent aren't supported yet, and will be supported in the future. 