### PR TITLE
Implement invokevirtual opcode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,8 @@ TESTS = \
 	Caller \
 	Constructor \
 	Field \
-	Static
+	Static \
+	Invokevirtual
 	
 check: $(addprefix tests/,$(TESTS:=-result.out))
 

--- a/classfile.c
+++ b/classfile.c
@@ -27,8 +27,16 @@ class_info_t get_class_info(FILE *class_file)
  */
 uint16_t get_number_of_parameters(method_t *method)
 {
-    /* Type descriptors have the length ( + #params + ) + return type */
-    return strlen(method->descriptor) - 3;
+    uint16_t num_param = 0;
+    for (size_t i = 1; method->descriptor[i] != ')'; ++i) {
+        /* if type is reference, skip class name */
+        if (method->descriptor[i] == 'L') {
+            while (method->descriptor[++i] != ';')
+                ;
+        }
+        num_param++;
+    }
+    return num_param;
 }
 
 /**

--- a/classfile.c
+++ b/classfile.c
@@ -279,13 +279,6 @@ method_t *get_methods(FILE *class_file, constant_pool_t *cp)
         assert(descriptor->tag == CONSTANT_Utf8 && "Expected a UTF8");
         method->descriptor = (char *) descriptor->info;
 
-        /* FIXME: this VM can only execute static methods, while every class
-         * has a constructor method <init>
-         */
-        if (strcmp(method->name, "<init>"))
-            assert((info.access_flags & IS_STATIC) &&
-                   "Only static methods are supported by this VM.");
-
         read_method_attributes(class_file, &info, &method->code, cp);
     }
 

--- a/stack.c
+++ b/stack.c
@@ -86,11 +86,13 @@ void *pop_ref(stack_frame_t *stack)
 void pop_to_local(stack_frame_t *stack, local_variable_t *locals)
 {
     stack_entry_type_t type = stack->store[stack->size - 1].type;
-    /* convert to integer */
+    /* push value from stack to locals */
     if (type >= STACK_ENTRY_BYTE && type <= STACK_ENTRY_LONG) {
-        int64_t value = pop_int(stack);
-        locals->entry.long_value = value;
+        locals->entry.long_value = pop_int(stack);
         locals->type = STACK_ENTRY_LONG;
+    } else if (type == STACK_ENTRY_REF) {
+        locals->entry.ptr_value = pop_ref(stack);
+        locals->type = STACK_ENTRY_REF;
     }
 }
 

--- a/tests/Invokevirtual.java
+++ b/tests/Invokevirtual.java
@@ -1,0 +1,27 @@
+class InvokevirtualA {
+    void print(int val) {
+        System.out.println(val);
+    }
+}
+
+class InvokevirtualB {
+    void print(InvokevirtualA obj, int val) {
+        obj.print(val);
+    }
+}
+
+class Invokevirtual {
+    int a;
+    public void print() {
+        System.out.println(a);
+    }
+    public static void main(String args[]) {
+        Invokevirtual x = new Invokevirtual();
+        InvokevirtualA obj1 = new InvokevirtualA();
+        InvokevirtualB obj2 = new InvokevirtualB();
+        x.a = 3;
+        x.print();
+        obj1.print(2);
+        obj2.print(obj1, 3);
+    }
+}


### PR DESCRIPTION
Now pitifulvm can handle `invokevirtual` opcode. However, current implementation doesn't support any method modifiers, so `invokevirtual` can access all methods in the class. Also, objects cannot invoke parent's methods, and this will be supported in the future.

Add a new test script: "Invokevirtual.java"