### PR TITLE
Support parent fields in getfield and putfield

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -13,3 +13,5 @@ UseTab: Never
 IndentWidth: 4
 BreakBeforeBraces: Linux
 AccessModifierOffset: -4
+ForEachMacros:
+  - list_for_each

--- a/classfile.h
+++ b/classfile.h
@@ -54,13 +54,15 @@ typedef struct {
     variable_t *static_var; /* store static fields in the class */
 } field_t;
 
-typedef struct {
+typedef struct class_file {
     constant_pool_t constant_pool;
     class_info_t *info;
     method_t *methods;
     field_t *fields;
     u2 fields_count;
     bool initialized;
+    struct class_file *next;
+    struct class_file *prev;
 } class_file_t;
 
 typedef struct {

--- a/list.h
+++ b/list.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#define init_list(list) list->prev = list->next = list;
+
+#define list_is_head(list, head) (list == head)
+
+#define list_add(new, head) \
+    head->next->prev = new; \
+    new->next = head->next; \
+    new->prev = head;       \
+    head->next = new;
+
+#define list_del(entry)              \
+    entry->prev->next = entry->next; \
+    entry->next->prev = entry->prev;
+
+#define list_for_each(pos, head) \
+    for (pos = (head)->next; !list_is_head(pos, (head)); pos = pos->next)

--- a/object-heap.h
+++ b/object-heap.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "classfile.h"
+#include "list.h"
 
-typedef struct {
+typedef struct object {
     variable_t *value;
     class_file_t *class;
     size_t fields_count;
+    struct object *parent;
 } object_t;
 
 typedef struct {

--- a/tests/Inherit.java
+++ b/tests/Inherit.java
@@ -1,5 +1,6 @@
 public class Inherit {
     static int x = 1;
+    int y = 5;
 
     public static void static_call() {
         System.out.println(1);
@@ -26,6 +27,20 @@ public class Inherit {
         System.out.println(obj.x);
         System.out.println(objA.x);
         System.out.println(objB.x);
+
+        /* check fields */
+        System.out.println(obj.y);
+        System.out.println(objA.y);
+        System.out.println(objB.y);
+        obj.y = 2;
+        System.out.println(obj.y);
+        System.out.println(objA.y);
+        System.out.println(objB.y);
+        objA.y = 3;
+        objB.y = 5;
+        System.out.println(obj.y);
+        System.out.println(objA.y);
+        System.out.println(objB.y);
 
         /* check static methods inheritance (compiler will replace objects with classes) */
         obj.static_call();


### PR DESCRIPTION
When pitifulvm create a new object, it will create the object itself and all its parents as objects and use linked list to link all related objects. When `getfield` or `putfield` are called, pitifulvm will try to find fields along the linked list.

Update `Inherit.java` in order to test parent fields.