### PR TITLE
Support java string and concatenation 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ TESTS = \
 	Static \
 	Invokevirtual \
 	Inherit \
-	Initializer
+	Initializer \
+	Strings
 	
 check: $(addprefix tests/,$(TESTS:=-result.out))
 

--- a/class-heap.c
+++ b/class-heap.c
@@ -109,6 +109,15 @@ void free_class_heap()
         }
         free(class_heap.class_info[i]->clazz->methods);
 
+        bootmethods_attr_t *bootstrap =
+            class_heap.class_info[i]->clazz->bootstrap;
+        if (bootstrap) {
+            for (u2 j = 0; j < bootstrap->num_bootstrap_methods; j++)
+                free(bootstrap->bootstrap_methods[j].bootstrap_arguments);
+            free(bootstrap->bootstrap_methods);
+            free(bootstrap);
+        }
+
         free(class_heap.class_info[i]->clazz);
         free(class_heap.class_info[i]->name);
         free(class_heap.class_info[i]);

--- a/classfile.h
+++ b/classfile.h
@@ -54,12 +54,26 @@ typedef struct {
     variable_t *static_var; /* store static fields in the class */
 } field_t;
 
+typedef struct {
+    u2 bootstrap_method_ref;
+    u2 num_bootstrap_arguments;
+    u2 *bootstrap_arguments;
+} bootmethods_t;
+
+typedef struct {
+    u2 attribute_name_index;
+    u4 attribute_length;
+    u2 num_bootstrap_methods;
+    bootmethods_t *bootstrap_methods;
+} bootmethods_attr_t;
+
 typedef struct class_file {
     constant_pool_t constant_pool;
     class_info_t *info;
     method_t *methods;
     field_t *fields;
     u2 fields_count;
+    bootmethods_attr_t *bootstrap;
     bool initialized;
     struct class_file *next;
     struct class_file *prev;
@@ -89,4 +103,7 @@ char *find_field_info_from_index(uint16_t idx,
                                  char **name_info,
                                  char **descriptor_info);
 void read_field_attributes(FILE *class_file, field_info *info);
+bootmethods_t *find_bootstrap_method(uint16_t idx, class_file_t *clazz);
+bootmethods_attr_t *read_bootstrap_attribute(FILE *class_file,
+                                             constant_pool_t *cp);
 field_t *get_fields(FILE *class_file, constant_pool_t *cp, class_file_t *clazz);

--- a/constant-pool.h
+++ b/constant-pool.h
@@ -13,9 +13,12 @@ typedef enum {
     CONSTANT_Integer = 3,
     CONSTANT_Long = 5,
     CONSTANT_Class = 7,
+    CONSTANT_String = 8,
     CONSTANT_FieldRef = 9,
     CONSTANT_MethodRef = 10,
     CONSTANT_NameAndType = 12,
+    CONSTANT_MethodHandle = 15,
+    CONSTANT_InvokeDynamic = 18,
 } const_pool_tag_t;
 
 typedef struct {
@@ -42,6 +45,20 @@ typedef struct {
 } CONSTANT_NameAndType_info;
 
 typedef struct {
+    u2 string_index;
+} CONSTANT_String_info;
+
+typedef struct {
+    u2 bootstrap_method_attr_index;
+    u2 name_and_type_index;
+} CONSTANT_InvokeDynamic_info;
+
+typedef struct {
+    u1 reference_kind;
+    u2 reference_index;
+} CONSTANT_MethodHandle_info;
+
+typedef struct {
     const_pool_tag_t tag;
     u1 *info;
 } const_pool_info;
@@ -58,3 +75,5 @@ const_pool_info *get_constant(constant_pool_t *constant_pool, u2 index);
 constant_pool_t get_constant_pool(FILE *class_file);
 CONSTANT_FieldOrMethodRef_info *get_methodref(constant_pool_t *cp, u2 idx);
 CONSTANT_Class_info *get_class_name(constant_pool_t *cp, u2 idx);
+CONSTANT_MethodHandle_info *get_method_handle(constant_pool_t *cp, u2 idx);
+char *get_string_utf(constant_pool_t *cp, u2 idx);

--- a/jvm.c
+++ b/jvm.c
@@ -578,6 +578,15 @@ stack_entry_t *execute(method_t *method,
         }
 
         /* Load object from local variable */
+        case i_aload: {
+            int32_t param = code_buf[pc + 1];
+            object_t *obj = locals[param].entry.ptr_value;
+
+            push_ref(op_stack, obj);
+            pc += 2;
+        } break;
+
+        /* Load object from local variable */
         case i_aload_0:
         case i_aload_1:
         case i_aload_2:

--- a/jvm.c
+++ b/jvm.c
@@ -101,6 +101,7 @@ typedef enum {
     i_invokevirtual = 0xb6,
     i_invokespecial = 0xb7,
     i_invokestatic = 0xb8,
+    i_invokedynamic = 0xba,
     i_new = 0xbb,
 } jvm_opcode_t;
 
@@ -501,11 +502,27 @@ stack_entry_t *execute(method_t *method,
              */
             int16_t param = code_buf[pc + 1];
 
-            /* get the constant */
-            uint8_t *info = get_constant(&constant_pool, param)->info;
-
-            /* need to check type */
-            push_int(op_stack, ((CONSTANT_Integer_info *) info)->bytes);
+            const_pool_info *info = get_constant(&constant_pool, param);
+            switch (info->tag) {
+            case CONSTANT_Integer: {
+                push_int(op_stack,
+                         ((CONSTANT_Integer_info *) info->info)->bytes);
+                break;
+            }
+            case CONSTANT_String: {
+                char *src =
+                    (char *) get_constant(
+                        &constant_pool,
+                        ((CONSTANT_String_info *) info->info)->string_index)
+                        ->info;
+                char *dest = create_string(clazz, src);
+                push_ref(op_stack, dest);
+                break;
+            }
+            default:
+                assert(0 && "ldc only support int and string");
+                break;
+            }
             pc += 2;
             break;
         }
@@ -1002,6 +1019,12 @@ stack_entry_t *execute(method_t *method,
                     printf("%ld\n", op);
                     break;
                 }
+                /* string */
+                case STACK_ENTRY_REF: {
+                    void *op = pop_ref(op_stack);
+                    printf("%s\n", (char *) op);
+                    break;
+                }
                 default:
                     printf("print type (%d) is not supported\n", element.type);
                     break;
@@ -1302,6 +1325,115 @@ stack_entry_t *execute(method_t *method,
             free(exec_res);
 
             pc += 3;
+            break;
+        }
+
+        /* Invokes a dynamic method */
+        case i_invokedynamic: {
+            uint8_t param1 = code_buf[pc + 1], param2 = code_buf[pc + 2];
+            uint16_t index = ((param1 << 8) | param2);
+
+            bootmethods_t *bootstrap_method =
+                find_bootstrap_method(index, clazz);
+            CONSTANT_MethodHandle_info *handle = get_method_handle(
+                &clazz->constant_pool, bootstrap_method->bootstrap_method_ref);
+
+            char *method_name, *method_descriptor;
+            find_method_info_from_index(handle->reference_index, clazz,
+                                        &method_name, &method_descriptor);
+
+            if (strcmp(method_name, "makeConcatWithConstants"))
+                assert(0 && "Only support makeConcatWithConstants");
+
+            char *arg = NULL;
+            arg = get_string_utf(&clazz->constant_pool,
+                                 bootstrap_method->bootstrap_arguments[0]);
+
+            /* In the first argument string, there are three types of character
+             * \1 (Unicode point 0001): an ordinary argument.
+             * \2 (Unicode point 0002): a constant.
+             * Any other char value: a single character constant.
+             *
+             * \1 will be replaced by value in the stack
+             * \2 will be replaced by value in other bootstrap arguments
+             */
+            uint16_t num_params = 0;
+            uint16_t num_constant = 0;
+            char *iter = arg;
+            while (*iter != '\0') {
+                if (*iter == 1 || *iter == 2) {
+                    num_params++;
+                }
+                iter++;
+            }
+            num_constant = strlen(arg) - num_params;
+            char **recipe = calloc(sizeof(char *), num_params);
+            size_t max_len = 0;
+
+            iter = arg;
+            int curr = 0,
+                arg_num = bootstrap_method->num_bootstrap_arguments - 1;
+            while (*iter != '\0') {
+                if (*iter == 1) {
+                    stack_entry_t element = top(op_stack);
+                    switch (element.type) {
+                    /* integer */
+                    case STACK_ENTRY_INT:
+                    case STACK_ENTRY_SHORT:
+                    case STACK_ENTRY_BYTE:
+                    case STACK_ENTRY_LONG: {
+                        int64_t value = pop_int(op_stack);
+                        /* 20 is the maximal digits in 64 bits sign integer */
+                        char str[20];
+                        /* integer to string */
+                        snprintf(str, 20, "%ld", value);
+                        char *dest = create_string(clazz, str);
+                        recipe[curr] = dest;
+                        break;
+                    }
+                    /* string */
+                    case STACK_ENTRY_REF: {
+                        recipe[curr] = (char *) pop_ref(op_stack);
+                        break;
+                    }
+                    default: {
+                        printf("unknown stack top type (%d)\n", element.type);
+                        break;
+                    }
+                    }
+                    max_len += strlen(recipe[curr++]);
+                } else if (*iter == 2) {
+                    recipe[curr] = get_string_utf(
+                        &clazz->constant_pool,
+                        bootstrap_method->bootstrap_arguments[arg_num--]);
+                    max_len += strlen(recipe[curr++]);
+                }
+                iter++;
+            }
+
+            max_len += num_constant;
+            char *result = calloc(max_len + 1, sizeof(char));
+
+            iter = arg;
+            while (*iter != '\0') {
+                if (*iter == 1 || *iter == 2) {
+                    strcat(result, recipe[--num_params]);
+                } else {
+                    strncat(result, iter, 1);
+                }
+                iter++;
+            }
+            result[max_len] = '\0';
+
+            char *dest = create_string(clazz, result);
+            push_ref(op_stack, dest);
+            free(recipe);
+            free(result);
+
+            /* two bytes values indicate the class in constant pool and the next
+             * two bytes are always zero, program counter should plus five.
+             */
+            pc += 5;
             break;
         }
 

--- a/object-heap.c
+++ b/object-heap.c
@@ -40,6 +40,25 @@ object_t *create_object(class_file_t *clazz)
     return new_obj;
 }
 
+char *create_string(class_file_t *clazz, char *src)
+{
+    size_t len = strlen(src);
+    char *dest = calloc((len + 1), sizeof(char));
+    strncpy(dest, src, len);
+
+    object_t *str_obj = malloc(sizeof(object_t));
+    str_obj->value = malloc(sizeof(variable_t));
+    str_obj->value->type = VAR_STR_PTR;
+    str_obj->value->value.ptr_value = dest;
+    str_obj->class = clazz;
+    str_obj->parent = NULL;
+    str_obj->fields_count = 1;
+
+    object_heap.objects[object_heap.length++] = str_obj;
+
+    return dest;
+}
+
 variable_t *find_field_addr(object_t *obj, char *name)
 {
     field_t *field = obj->class->fields;
@@ -57,6 +76,11 @@ void free_object_heap()
         /* free object and all its parent */
         for (object_t *cur = object_heap.objects[i], *next; cur; cur = next) {
             next = cur->parent;
+            if (cur->value) {
+                if (cur->value->type == VAR_STR_PTR) {
+                    free(cur->value->value.ptr_value);
+                }
+            }
             free(cur->value);
             free(cur);
         }

--- a/object-heap.h
+++ b/object-heap.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string.h>
+
 #include "classfile.h"
 #include "list.h"
 
@@ -18,4 +20,5 @@ typedef struct {
 void init_object_heap();
 void free_object_heap();
 object_t *create_object(class_file_t *clazz);
+char *create_string(class_file_t *clazz, char *src);
 variable_t *find_field_addr(object_t *obj, char *name);

--- a/tests/Strings.java
+++ b/tests/Strings.java
@@ -1,0 +1,23 @@
+public class Strings {
+    public static String f(String x) {
+        return x + " abc " + x;
+    }
+    public static void main(String args[])
+    {
+        String str1 = "Hello";
+        String str2 = " Jvm ";
+        String str3 = "string";
+        String str4 = "x\bx\tx\\x\nx\1x\2x\3x\4x\5x\6x";
+        int x = 100;
+        long y = java.lang.Long.MAX_VALUE;
+        /* test string argument */
+        System.out.println(f("test"));
+        /* test string concat */
+        System.out.println(str1 + " constant " + str2);
+        System.out.println(str1 + str2 + str3 + str4);
+        /* test string concat with number */
+        System.out.println("1" + 2 + x + "3" + y + 0.8 + str2);
+        /* test invokedynamic arguments */
+        System.out.println("prefix \1" + str1 + "suffix \2");
+    }
+}

--- a/type.h
+++ b/type.h
@@ -13,7 +13,8 @@ typedef enum {
     VAR_SHORT = 2,
     VAR_INT = 3,
     VAR_LONG = 4,
-    VAR_PTR = 5, /* reference */
+    VAR_PTR = 5,    /* reference */
+    VAR_STR_PTR = 6 /* string reference */
 } variable_type_t;
 
 typedef union {


### PR DESCRIPTION
Implement `invokedynamic` opcode that can run bootstrap methods in order to do string concatenation, and modify `ldc` so that it can create new string.

Every string will be created by `create_string` function, which can place each string into heap so that strings can be released correctly.

Note that current implmentmentation of `invokedynamic` only supports `makeConcatWithConstants`, so callsite and lambda aren't supported.