### PR TITLE
Support Java array

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,8 @@ TESTS = \
 	Invokevirtual \
 	Inherit \
 	Initializer \
-	Strings
+	Strings \
+	Array
 	
 check: $(addprefix tests/,$(TESTS:=-result.out))
 

--- a/object-heap.h
+++ b/object-heap.h
@@ -21,4 +21,13 @@ void init_object_heap();
 void free_object_heap();
 object_t *create_object(class_file_t *clazz);
 char *create_string(class_file_t *clazz, char *src);
+void **build_array(uint8_t depth,
+                   int dimension,
+                   int *n_elements,
+                   size_t type_size);
+void free_array(object_t *obj, uint8_t depth, int dimension, void **arr);
+void *create_array(class_file_t *clazz,
+                   uint8_t dimension,
+                   int *dimensions,
+                   size_t type_size);
 variable_t *find_field_addr(object_t *obj, char *name);

--- a/type.h
+++ b/type.h
@@ -13,8 +13,9 @@ typedef enum {
     VAR_SHORT = 2,
     VAR_INT = 3,
     VAR_LONG = 4,
-    VAR_PTR = 5,    /* reference */
-    VAR_STR_PTR = 6 /* string reference */
+    VAR_PTR = 5,       /* reference */
+    VAR_STR_PTR = 6,   /* string reference */
+    VAR_ARRAY_PTR = 7, /* array reference */
 } variable_type_t;
 
 typedef union {
@@ -29,3 +30,14 @@ typedef struct {
     value_t value;
     variable_type_t type;
 } variable_t;
+
+typedef enum {
+    T_BOOLEN = 4,
+    T_CHAR = 5,
+    T_FLOAT = 6,
+    T_DOUBLE = 7,
+    T_BYTE = 8,
+    T_SHORT = 9,
+    T_INT = 10,
+    T_LONG = 11
+} array_type_t;


### PR DESCRIPTION
It supports all primitive types and reference type. However, it cannot store Java String into array because `String` class have not supported yet.

`create_array` can create a new object that contains array so heap can release the object and the array.

Add array related opcodes:

* aastore, aaload
* bastore, baload
* castore, caload
* sastore, saload
* iastore, iaload
* lastore, laload
* newarray, anewarray, multianewarray

Add a new test script: "Array.java"